### PR TITLE
README.md: small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ use tree_sitter::{Parser, Language};
 
 // ...
 
-let parser = Parser::new();
+let mut parser = Parser::new();
 ```
 
 Then assign a language to the parser. Tree-sitter languages consist of generated C code. To use them from rust, you must declare them as `extern "C"` functions and invoke them with `unsafe`:
 
 ```rust
-extern "C" fn tree_sitter_c() -> Language;
-extern "C" fn tree_sitter_rust() -> Language;
-extern "C" fn tree_sitter_javascript() -> Language;
+extern "C" { fn tree_sitter_c() -> Language; }
+extern "C" { fn tree_sitter_rust() -> Language; }
+extern "C" { fn tree_sitter_javascript() -> Language; }
 
 let language = unsafe { tree_sitter_rust() };
 parser.set_language(language).unwrap();


### PR DESCRIPTION
To call .set_language on parser, it needs to be mut; also, the syntax
for the extern "C" blocks seemed to be a bit off.

Both now corresponds to what's in the tests.