### PR TITLE
Adding a tree walker example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 target
 Cargo.lock
-fixtures/tree-sitter-rust
+fixtures/

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ extern crate cc;
 
 use std::env;
 use std::path::PathBuf;
+use std::fs;
 
 fn main() {
     let mut config = cc::Build::new();
@@ -17,10 +18,20 @@ fn main() {
         .file(root_path.join("src").join("runtime").join("runtime.c"));
 
     if env::var("RUST_TREE_SITTER_TEST").is_ok() {
-        let parser_dir: PathBuf = ["fixtures", "tree-sitter-rust", "src"].iter().collect();
-        config
-            .file(parser_dir.join("parser.c"))
-            .file(parser_dir.join("scanner.c"));
+        let paths = fs::read_dir("fixtures").unwrap();
+
+        for path in paths {
+            let mut parser_dir: PathBuf = ["fixtures", path.unwrap().file_name().to_str().unwrap(), "src"].iter().collect();
+            if parser_dir.join("parser.c").exists() {
+               config.file(parser_dir.join("parser.c"));
+            }
+            if parser_dir.join("scanner.c").exists() {
+               config.file(parser_dir.join("scanner.c"));
+            }
+//            if parser_dir.join("scanner.cc").exists() {
+//               config.file(parser_dir.join("scanner.cc"));
+//            }
+        }
     }
 
     config.compile("tree-sitter-runtime");

--- a/script/fetch-test-fixtures.sh
+++ b/script/fetch-test-fixtures.sh
@@ -1,14 +1,41 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-grammar_dir='fixtures/tree-sitter-rust'
-grammar_url='https://github.com/tree-sitter/tree-sitter-rust'
+GRAMMARS_DIR=$(dirname $0)/../fixtures
 
-if [ ! -d $grammar_dir ]; then
-  git clone $grammar_url $grammar_dir --depth=1
-fi
+fetch_grammar() {
+  local grammar=$1
+  local ref=$2
+  local grammar_dir=${GRAMMARS_DIR}/${grammar}
+  local grammar_url=https://github.com/tree-sitter/tree-sitter-${grammar}
 
-(
-  cd $grammar_dir;
-  git fetch origin master --depth=1
-  git reset --hard origin/master;
-)
+  echo "Updating ${grammar} grammar..."
+
+  if [ ! -d $grammar_dir ]; then
+    git clone $grammar_url $grammar_dir --depth=1
+  fi
+
+  (
+    cd $grammar_dir
+    git fetch origin $ref --depth=1
+    git reset --hard FETCH_HEAD
+  )
+}
+
+#fetch_grammar embedded-template master
+fetch_grammar javascript        master
+fetch_grammar json              master
+fetch_grammar c                 master
+#fetch_grammar cpp               master
+#fetch_grammar python            master
+fetch_grammar go                master
+#fetch_grammar ruby              master
+fetch_grammar typescript        master
+#fetch_grammar bash              master
+#fetch_grammar html              master
+fetch_grammar rust              master
+fetch_grammar scala             master
+fetch_grammar css               master
+fetch_grammar java              master
+#fetch_grammar haskell           master
+#fetch_grammar php               master
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,57 @@
+extern crate tree_sitter;
+use tree_sitter::{Parser, Language};
+
+fn main() {
+  let mut parser = Parser::new();
+
+  extern "C" { fn tree_sitter_rust() -> Language; }
+
+  let language = unsafe { tree_sitter_rust() };
+  parser.set_language(language).unwrap();
+
+  let source_code = "fn test() {}";
+  println!("source: {}", source_code);
+  let tree = parser.parse_str(source_code, None).unwrap();
+  let root_node = tree.root_node();
+  println!("AST: {}", root_node.to_sexp());
+
+  let mut indent = 0;
+  print_node(&root_node, source_code, indent);
+  let mut tree_cursor = root_node.walk();
+  let mut level = 0;
+  let mut child_printed = false;
+  while true {
+    if tree_cursor.goto_next_sibling() {
+      child_printed = false;
+      print_node(&tree_cursor.node(), source_code, indent);
+      if tree_cursor.goto_first_child() {
+        indent +=1;
+        level += 1;
+        print_node(&tree_cursor.node(), source_code, indent);
+      }
+    } else if !child_printed && tree_cursor.goto_first_child() {
+      indent +=1;
+      print_node(&tree_cursor.node(), source_code, indent);
+    } else {
+        if level > 0 {
+          tree_cursor.goto_parent();
+          child_printed = true;
+          level -= 1;
+          indent -=1;
+        } else {
+          break;
+        }
+    }
+  }
+}
+
+fn print_node(node: &tree_sitter::Node, source_code: &str, indent: usize) {
+  let separator = "  ".repeat(indent);
+
+  println!("{}- node: {}", separator, node.to_sexp());
+  println!("{}  kind: {}", separator, node.kind());
+  println!("{}  start: {}, {}", separator, node.start_position().row, node.start_position().column);
+  println!("{}  end: {}, {}", separator, node.end_position().row, node.end_position().column);
+  let chunk:String = source_code.chars().skip(node.start_byte()).take(node.end_byte()-node.start_byte()).collect();
+  println!("{}  content: {}", separator, chunk);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,37 +1,93 @@
 extern crate tree_sitter;
 use tree_sitter::{Parser, Language};
+use std::env;
 
 fn main() {
   let mut parser = Parser::new();
 
   extern "C" { fn tree_sitter_rust() -> Language; }
+  extern "C" { fn tree_sitter_c() -> Language; }
+  extern "C" { fn tree_sitter_java() -> Language; }
+  extern "C" { fn tree_sitter_javascript() -> Language; }
+  extern "C" { fn tree_sitter_python() -> Language; }
+  extern "C" { fn tree_sitter_ruby() -> Language; }
+  extern "C" { fn tree_sitter_haskell() -> Language; }
+  extern "C" { fn tree_sitter_cpp() -> Language; }
+  extern "C" { fn tree_sitter_go() -> Language; }
+  extern "C" { fn tree_sitter_bash() -> Language; }
+  extern "C" { fn tree_sitter_css() -> Language; }
+  extern "C" { fn tree_sitter_json() -> Language; }
+  extern "C" { fn tree_sitter_php() -> Language; }
 
-  let language = unsafe { tree_sitter_rust() };
+  let args: Vec<String> = env::args().collect();
+
+  let mut source_code = "fn test() {}";
+  if args.len() > 1 {
+    source_code = &args[1];
+  }
+  println!("source: {}", source_code);
+
+  let mut language_name = "rust";
+  if args.len() > 2 {
+    language_name = &args[2];
+  }
+  let mut language = unsafe { tree_sitter_rust() };
+  if language_name == "c" {
+    language = unsafe { tree_sitter_c() };
+//  } else if language_name == "cpp" {
+//    language = unsafe { tree_sitter_cpp() };
+  } else if language_name == "go" {
+    language = unsafe { tree_sitter_go() };
+  } else if language_name == "javascript" {
+    language = unsafe { tree_sitter_javascript() };
+  } else if language_name == "java" {
+    language = unsafe { tree_sitter_java() };
+//  } else if language_name == "embedded_template" {
+//    language = unsafe { tree_sitter_embedded_template() };
+//  } else if language_name == "html" {
+//    language = unsafe { tree_sitter_html() };
+//  } else if language_name == "python" {
+//    language = unsafe { tree_sitter_python() };
+//  } else if language_name == "ruby" {
+//    language = unsafe { tree_sitter_ruby() };
+//  } else if language_name == "haskell" {
+//    language = unsafe { tree_sitter_haskell() };
+//  } else if language_name == "bash" {
+//    language = unsafe { tree_sitter_bash() };
+//  } else if language_name == "php" {
+//    language = unsafe { tree_sitter_php() };
+  } else if language_name == "css" {
+    language = unsafe { tree_sitter_css() };
+  } else if language_name == "json" {
+    language = unsafe { tree_sitter_json() };
+  } else if language_name == "rust" {
+    language = unsafe { tree_sitter_rust() };
+  } else {
+    language = unsafe { tree_sitter_rust() };
+  }
   parser.set_language(language).unwrap();
 
-  let source_code = "fn test() {}";
-  println!("source: {}", source_code);
-  let tree = parser.parse_str(source_code, None).unwrap();
+  let tree = parser.parse_str(&source_code, None).unwrap();
   let root_node = tree.root_node();
   println!("AST: {}", root_node.to_sexp());
 
   let mut indent = 0;
-  print_node(&root_node, source_code, indent);
+  print_node(&root_node, &source_code, indent);
   let mut tree_cursor = root_node.walk();
   let mut level = 0;
   let mut child_printed = false;
-  while true {
+  loop {
     if tree_cursor.goto_next_sibling() {
       child_printed = false;
-      print_node(&tree_cursor.node(), source_code, indent);
+      print_node(&tree_cursor.node(), &source_code, indent);
       if tree_cursor.goto_first_child() {
         indent +=1;
         level += 1;
-        print_node(&tree_cursor.node(), source_code, indent);
+        print_node(&tree_cursor.node(), &source_code, indent);
       }
     } else if !child_printed && tree_cursor.goto_first_child() {
       indent +=1;
-      print_node(&tree_cursor.node(), source_code, indent);
+      print_node(&tree_cursor.node(), &source_code, indent);
     } else {
         if level > 0 {
           tree_cursor.goto_parent();

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,10 @@ fn main() {
   let mut level = 0;
   let mut child_printed = false;
   loop {
-    if tree_cursor.goto_next_sibling() {
+    if !child_printed && tree_cursor.goto_first_child() {
+      indent +=1;
+      print_node(&tree_cursor.node(), &source_code, indent);
+    } else if tree_cursor.goto_next_sibling() {
       child_printed = false;
       print_node(&tree_cursor.node(), &source_code, indent);
       if tree_cursor.goto_first_child() {
@@ -85,9 +88,6 @@ fn main() {
         level += 1;
         print_node(&tree_cursor.node(), &source_code, indent);
       }
-    } else if !child_printed && tree_cursor.goto_first_child() {
-      indent +=1;
-      print_node(&tree_cursor.node(), &source_code, indent);
     } else {
         if level > 0 {
           tree_cursor.goto_parent();


### PR DESCRIPTION
I know "src/main.rs" is not the right place to put this code, but as rust newbie, I'm looking for a friend:

- I use RUST_TREE_SITTER_TEST=true and fech the fixtures to have the tree-sitter-rust parser avaliable
   - how to add all other parsers?

- This code walks correctly in a rust source code, how to add this a a different repo with cargo
   - use this repo as a module or crate (I cannot install it with cargo install)
   - Colorize output with a crate
   - Maybe reproduce this walker with node cli?
   - Add options to select other parser, and provide source_code to parse from command line

Output from `cargo run`

```
source: fn test() {}
AST: (source_file (function_item (identifier) (parameters) (block)))
- node: (source_file (function_item (identifier) (parameters) (block)))
  kind: source_file
  start: 0, 0
  end: 0, 12
  content: fn test() {}
  - node: (function_item (identifier) (parameters) (block))
    kind: function_item
    start: 0, 0
    end: 0, 12
    content: fn test() {}
    - node: (fn)
      kind: fn
      start: 0, 0
      end: 0, 2
      content: fn
    - node: (identifier)
      kind: identifier
      start: 0, 3
      end: 0, 7
      content: test
    - node: (parameters)
      kind: parameters
      start: 0, 7
      end: 0, 9
      content: ()
      - node: (()
        kind: (
        start: 0, 7
        end: 0, 8
        content: (
      - node: ())
        kind: )
        start: 0, 8
        end: 0, 9
        content: )
    - node: (block)
      kind: block
      start: 0, 10
      end: 0, 12
      content: {}
      - node: ({)
        kind: {
        start: 0, 10
        end: 0, 11
        content: {
      - node: (})
        kind: }
        start: 0, 11
        end: 0, 12
        content: }
```