### PR TITLE
Parse Bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter"
 description = "Rust bindings to the Tree-sitter parsing library"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Max Brunsfeld <maxbrunsfeld@gmail.com>"]
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
Hiya @maxbrunsfeld! As discussed before, this PR changes the public API of `tree-sitter` to take anything that resembles bytes, so we can stop performing the valid UTF8 checks from Treelights.

`Parse::parse<T>` now takes `String`, `&str`, `Vec<u8>`, `&[u8]` or anything resembling that. The old `parse_str` has been marked as deprecated.

Let me know how is this looking!